### PR TITLE
Connection pooling and session concurrency

### DIFF
--- a/app/library/postgres.py
+++ b/app/library/postgres.py
@@ -22,37 +22,37 @@ from models.scene import Scene
 from models.text import Text
 
 
-async def get_text_from_postgres(text_id: str):
-    text_obj = get_text(text_id)
+async def get_text_from_postgres(text_id: str, session):
+    text_obj = get_text(text_id, session)
     if text_obj is None:
         raise ValueError("Invalid Text ID")
 
     return text_obj.as_dict()
 
 
-async def get_solved_from_postgres(object_id: str):
-    object_obj = await get_object_from_postgres(object_id)
+async def get_solved_from_postgres(object_id: str, session):
+    object_obj = await get_object_from_postgres(object_id, session)
 
     return object_obj["next_objects"]
 
 
-async def post_asset_to_postgres(data: dict):
+async def post_asset_to_postgres(data: dict, session):
     asset_model = Asset(**data)
-    asset_model = create_entity(asset_model)
+    asset_model = create_entity(asset_model, session)
 
     return asset_model.as_dict()
 
 
-async def get_object_from_postgres(object_id: str):
-    object_obj = get_object(object_id)
+async def get_object_from_postgres(object_id: str, session):
+    object_obj = get_object(object_id, session)
     if object_obj is None:
         raise ValueError("Object ID not valid")
 
     return object_obj.as_dict()
 
 
-async def get_scene_from_postgres(scene_id: str):
-    scene_obj = get_scene(scene_id)
+async def get_scene_from_postgres(scene_id: str, session):
+    scene_obj = get_scene(scene_id, session)
     if scene_obj is None:
         raise ValueError("Invalid Scene ID")
 
@@ -60,101 +60,101 @@ async def get_scene_from_postgres(scene_id: str):
 
     objects = []
     for object_id in response["object_ids"]:
-        objects.append(await get_object_from_postgres(object_id))
+        objects.append(await get_object_from_postgres(object_id, session))
 
     response["objects"] = objects
     return response
 
 
-async def get_loading_screen_from_postgres():
+async def get_loading_screen_from_postgres(session):
     # TODO: get actual loading scene from postgres once we have it
-    return await get_scene_from_postgres("123")
+    return await get_scene_from_postgres("123", session)
 
 
-async def get_asset_from_postgres(asset_id: str):
-    asset_obj = get_asset(asset_id)
+async def get_asset_from_postgres(asset_id: str, session):
+    asset_obj = get_asset(asset_id, session)
     if asset_obj is None:
         raise ValueError("Asset ID not valid")
 
     return asset_obj.as_dict()
 
 
-async def delete_asset_from_postgres(asset_id: str):
-    if not delete_asset(asset_id):
+async def delete_asset_from_postgres(asset_id: str, session):
+    if not delete_asset(asset_id, session):
         raise ValueError("Asset ID not valid")
 
     response = {"message": "Deleted successfully"}
     return response
 
 
-async def update_asset_from_postgres(asset_id: str, data: dict):
-    num_assets_updated = put_asset(asset_id, data)
+async def update_asset_from_postgres(asset_id: str, data: dict, session):
+    num_assets_updated = put_asset(asset_id, data, session)
     if num_assets_updated == 0:
         raise ValueError("Invalid Asset ID")
-    return await get_asset_from_postgres(asset_id)
+    return await get_asset_from_postgres(asset_id, session)
 
 
-async def post_scenario_to_postgres(data: dict):
+async def post_scenario_to_postgres(data: dict, session):
     scenario_obj = Scenario(**data)
-    scenario_obj = create_entity(scenario_obj)
+    scenario_obj = create_entity(scenario_obj, session)
     return scenario_obj.as_dict()
 
 
-async def get_scenario_from_postgres(scenario_id: str):
-    scenario_obj = get_scenario(scenario_id)
+async def get_scenario_from_postgres(scenario_id: str, session):
+    scenario_obj = get_scenario(scenario_id, session)
     if scenario_obj is None:
         raise ValueError("Scenario ID not valid")
 
     return scenario_obj.as_dict()
 
 
-async def delete_scenario_from_postgres(scenario_id: str):
-    if not delete_scenario(scenario_id):
+async def delete_scenario_from_postgres(scenario_id: str, session):
+    if not delete_scenario(scenario_id, session):
         raise ValueError("Scenario ID not valid")
 
     response = {"message": "Deleted successfully"}
     return response
 
 
-async def update_scenario_from_postgres(scenario_id: str, data: dict):
-    num_scenarios_updated = put_scenario(scenario_id, data)
+async def update_scenario_from_postgres(scenario_id: str, data: dict, session):
+    num_scenarios_updated = put_scenario(scenario_id, data, session)
     if num_scenarios_updated == 0:
         raise ValueError("Invalid Scenario ID")
-    return await get_scenario_from_postgres(scenario_id)
+    return await get_scenario_from_postgres(scenario_id, session)
 
 
-async def post_scene_to_postgres(data: dict):
+async def post_scene_to_postgres(data: dict, session):
     scene_model = Scene(**data)
-    scene_model = create_entity(scene_model)
+    scene_model = create_entity(scene_model, session)
     return scene_model.as_dict()
 
 
-async def update_scene_from_postgres(scene_id: str, data: dict):
-    num_scenes_updated = put_scene(scene_id, data)
+async def update_scene_from_postgres(scene_id: str, data: dict, session):
+    num_scenes_updated = put_scene(scene_id, data, session)
     if num_scenes_updated == 0:
         raise ValueError("Invalid scene ID")
-    return await get_scene_from_postgres(scene_id)
+    return await get_scene_from_postgres(scene_id, session)
 
 
-async def delete_scene_from_postgres(scene_id: str):
+async def delete_scene_from_postgres(scene_id: str, session):
     # Get scene first
-    scene_obj: Scene = get_scene(scene_id)
+    scene_obj: Scene = get_scene(scene_id, session)
     if scene_obj is None:
         raise ValueError("Invalid Scene ID")
 
     # Delete all objects in the scene
     for object_id in scene_obj.object_ids:
-        await delete_object_in_postgres(scene_id, object_id)
+        await delete_object_in_postgres(scene_id, object_id, session)
 
     # Delete the scene
-    if not delete_scene(scene_id):
+    if not delete_scene(scene_id, session):
         raise ValueError("Scene ID not valid")
 
     response = {"message": "Deleted successfully"}
     return response
 
 
-async def duplicate_scenario(scenario_id: str):
+async def duplicate_scenario(scenario_id: str, session):
     # TODO: actual duplication in postgres
     sample_response = {
         "message": "Duplicated scenario with id " + scenario_id,
@@ -163,7 +163,7 @@ async def duplicate_scenario(scenario_id: str):
     return sample_response
 
 
-async def duplicate_scene(scene_id: str):
+async def duplicate_scene(scene_id: str, session):
     # TODO: actual duplication in postgres
     sample_response = {
         "message": "Duplicated scene with id " + scene_id,
@@ -172,13 +172,13 @@ async def duplicate_scene(scene_id: str):
     return sample_response
 
 
-async def post_object_to_postgres(scene_id: str, data: dict):
+async def post_object_to_postgres(scene_id: str, data: dict, session):
     object_model = Object(**data)
 
     # Ensure each object exists and it is either an object, as postgres won't do validation for us
     for next_obj in object_model.next_objects:
         try:
-            await get_object_from_postgres(next_obj["id"])
+            await get_object_from_postgres(next_obj["id"], session)
         except KeyError:
             raise ValueError("one of the objects in next_objects is missing id")
         except ValueError:
@@ -187,42 +187,42 @@ async def post_object_to_postgres(scene_id: str, data: dict):
             )
 
     # Make sure the scene exists
-    scene_obj: Scene = get_scene(scene_id)
+    scene_obj: Scene = get_scene(scene_id, session)
     if scene_obj is None:
         raise ValueError("Invalid Scene ID")
 
-    object_model = create_entity(object_model)
+    object_model = create_entity(object_model, session)
 
     # Add object to the scene
     scene_obj.object_ids.append(object_model.id)
-    put_scene(scene_id, scene_obj.as_dict())
+    put_scene(scene_id, scene_obj.as_dict(), session)
 
     return object_model.as_dict()
 
 
-async def update_object_in_postgres(scene_id: str, object_id: str, data: dict):
-    num_objects_updated = put_object(object_id, data)
+async def update_object_in_postgres(scene_id: str, object_id: str, data: dict, session):
+    num_objects_updated = put_object(object_id, data, session)
     if num_objects_updated == 0:
         raise ValueError("Invalid Object ID")
 
-    return await get_object_from_postgres(object_id)
+    return await get_object_from_postgres(object_id, session)
 
 
-async def delete_object_in_postgres(scene_id: str, object_id: str):
+async def delete_object_in_postgres(scene_id: str, object_id: str, session):
     # Make sure the scene exists
-    scene_obj: Scene = get_scene(scene_id)
+    scene_obj: Scene = get_scene(scene_id, session)
     if scene_obj is None:
         raise ValueError("Invalid Scene ID")
 
-    object_model = await get_object_from_postgres(object_id)
+    object_model = await get_object_from_postgres(object_id, session)
 
-    if not delete_object(object_id):
+    if not delete_object(object_id, session):
         raise ValueError("Object ID not valid")
 
     # Remove object from the scene
     if int(object_id) in scene_obj.object_ids:
         scene_obj.object_ids.remove(int(object_id))
-        put_scene(scene_id, scene_obj.as_dict())
+        put_scene(scene_id, scene_obj.as_dict(), session)
 
     # Delete any texts associated with the object
     if object_model["text_id"]:
@@ -232,19 +232,19 @@ async def delete_object_in_postgres(scene_id: str, object_id: str):
     return response
 
 
-async def post_text_to_postgres(scene_id: str, data: dict):
+async def post_text_to_postgres(scene_id: str, data: dict, session):
     text_obj = Text(**data)
-    text_obj = create_entity(text_obj)
+    text_obj = create_entity(text_obj, session)
 
     return text_obj.as_dict()
 
 
-async def put_text_to_postgres(scene_id: str, text_id: str, data: dict):
-    num_texts_updated = put_text(text_id, data)
+async def put_text_to_postgres(scene_id: str, text_id: str, data: dict, session):
+    num_texts_updated = put_text(text_id, data, session)
     if num_texts_updated == 0:
         raise ValueError("Invalid Text ID")
 
-    return await get_text_from_postgres(text_id)
+    return await get_text_from_postgres(text_id, session)
 
 
 async def delete_text_from_postgres(
@@ -259,11 +259,11 @@ async def delete_text_from_postgres(
     # if not obj_model:
     #     obj_model = get_object(text_obj.object_id)
     #
-    # if obj_model and obj_model.text_id == int(text_id):
+    # if obj_model and obj_model.text_id == int(text_id, session):
     #     obj_model.text_id = None
     #     put_object(obj_model.id, obj_model.as_dict())
     #
-    # if not delete_text(text_id):
+    # if not delete_text(text_id, session):
     #     raise ValueError("Text ID not valid")
     #
     # # Recursively delete the next texts in the list

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -11,8 +11,16 @@ password = config.get("postgres.password", "")
 db_url = config.get("postgres.db_url").format(
     user=user, password=password, database=database, hostname=hostname
 )
-engine = create_engine(db_url, pool_size=20, max_overflow=5)
+engine = create_engine(db_url, pool_size=2, max_overflow=1)
 
 Session = sessionmaker(bind=engine)
 
 Base = declarative_base()
+
+
+def get_session():
+    return Session()
+
+
+def return_session(session):
+    session.close()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -11,7 +11,7 @@ password = config.get("postgres.password", "")
 db_url = config.get("postgres.db_url").format(
     user=user, password=password, database=database, hostname=hostname
 )
-engine = create_engine(db_url)
+engine = create_engine(db_url, pool_size=20, max_overflow=5)
 
 Session = sessionmaker(bind=engine)
 

--- a/app/models/db_client.py
+++ b/app/models/db_client.py
@@ -5,14 +5,13 @@ from models.scene import Scene
 from models.statistics import Statistics
 from models.text import Text
 
-from . import Base, Session, engine
+from . import Base, engine
 
 
 # TODO: move session creating and closing out of these individual calls
-def create_entity(data):
+def create_entity(data, session):
     # create the session
     Base.metadata.create_all(engine)
-    session = Session()
 
     # add the entity to the session
     session.add(data)
@@ -23,40 +22,30 @@ def create_entity(data):
     # refresh the data to get the id autopopulated in database
     session.refresh(data)
 
-    # close the session
-    session.close()
-
     # return the id to the caller
     return data
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_assets():
-    session = Session()
+def get_assets(session):
     assets = session.query(Asset).all()
-    session.close()
     return assets
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_asset(id):
-    session = Session()
+def get_asset(id, session):
     asset = session.query(Asset).get(id)
-    session.close()
     return asset
 
 
 # TODO: move session creating and closing out of these individual calls
-def delete_asset(id):
+def delete_asset(id, session):
     try:
-        session = Session()
-
         exists = session.query(Asset).filter(Asset.id == id).first() is not None
         if exists:
             session.query(Asset).filter(Asset.id == id).delete()
             session.commit()
 
-        session.close()
     except Exception as e:
         raise e
 
@@ -64,32 +53,25 @@ def delete_asset(id):
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_objects():
-    session = Session()
+def get_objects(session):
     objects = session.query(Object).all()
-    session.close()
     return objects
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_object(id):
-    session = Session()
+def get_object(id, session):
     obj = session.query(Object).get(id)
-    session.close()
     return obj
 
 
 # TODO: move session creating and closing out of these individual calls
-def delete_object(id):
+def delete_object(id, session):
     try:
-        session = Session()
-
         exists = session.query(Object).filter(Object.id == id).first() is not None
         if exists:
             session.query(Object).filter(Object.id == id).delete()
             session.commit()
 
-        session.close()
     except Exception as e:
         raise e
 
@@ -97,32 +79,25 @@ def delete_object(id):
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_scenarios():
-    session = Session()
+def get_scenarios(session):
     scenarios = session.query(Scenario).all()
-    session.close()
     return scenarios
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_scenario(id):
-    session = Session()
+def get_scenario(id, session):
     scenario = session.query(Scenario).get(id)
-    session.close()
     return scenario
 
 
 # TODO: move session creating and closing out of these individual calls
-def delete_scenario(id):
+def delete_scenario(id, session):
     try:
-        session = Session()
-
         exists = session.query(Scenario).filter(Scenario.id == id).first() is not None
         if exists:
             session.query(Scenario).filter(Scenario.id == id).delete()
             session.commit()
 
-        session.close()
     except Exception as e:
         raise e
 
@@ -130,32 +105,25 @@ def delete_scenario(id):
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_scenes():
-    session = Session()
+def get_scenes(session):
     scenes = session.query(Scene).all()
-    session.close()
     return scenes
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_scene(id):
-    session = Session()
+def get_scene(id, session):
     scene = session.query(Scene).get(id)
-    session.close()
     return scene
 
 
 # TODO: move session creating and closing out of these individual calls
-def delete_scene(id):
+def delete_scene(id, session):
     try:
-        session = Session()
-
         exists = session.query(Scene).filter(Scene.id == id).first() is not None
         if exists:
             session.query(Scene).filter(Scene.id == id).delete()
             session.commit()
 
-        session.close()
     except Exception as e:
         raise e
 
@@ -163,26 +131,20 @@ def delete_scene(id):
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_statistics():
-    session = Session()
+def get_statistics(session):
     stats = session.query(Statistics).all()
-    session.close()
     return stats
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_statistic(id):
-    session = Session()
+def get_statistic(id, session):
     stat = session.query(Statistics).get(id)
-    session.close()
     return stat
 
 
 # TODO: move session creating and closing out of these individual calls
-def delete_statistic(id):
+def delete_statistic(id, session):
     try:
-        session = Session()
-
         exists = (
             session.query(Statistics).filter(Statistics.id == id).first() is not None
         )
@@ -190,7 +152,6 @@ def delete_statistic(id):
             session.query(Statistics).filter(Statistics.id == id).delete()
             session.commit()
 
-        session.close()
     except Exception as e:
         raise e
 
@@ -198,127 +159,108 @@ def delete_statistic(id):
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_texts():
-    session = Session()
+def get_texts(session):
     texts = session.query(Text).all()
-    session.close()
     return texts
 
 
 # TODO: move session creating and closing out of these individual calls
-def get_text(id):
-    session = Session()
+def get_text(id, session):
     text = session.query(Text).get(id)
-    session.close()
     return text
 
 
 # TODO: move session creating and closing out of these individual calls
-def put_asset(id, data):
+def put_asset(id, data, session):
     try:
-        session = Session()
         asset = (
             session.query(Asset)
             .filter(Asset.id == id)
             .update(data, synchronize_session="fetch")
         )
         session.commit()
-        session.close()
     except Exception as e:
         raise e
     return asset
 
 
 # TODO: move session creating and closing out of these individual calls
-def put_object(id, data):
+def put_object(id, data, session):
     try:
-        session = Session()
         obj = (
             session.query(Object)
             .filter(Object.id == id)
             .update(data, synchronize_session="fetch")
         )
         session.commit()
-        session.close()
     except Exception as e:
         raise e
     return obj
 
 
 # TODO: move session creating and closing out of these individual calls
-def put_scenario(id, data):
+def put_scenario(id, data, session):
     try:
-        session = Session()
         scenario = (
             session.query(Scenario)
             .filter(Scenario.id == id)
             .update(data, synchronize_session="fetch")
         )
         session.commit()
-        session.close()
     except Exception as e:
         raise e
     return scenario
 
 
 # TODO: move session creating and closing out of these individual calls
-def put_scene(id, data):
+def put_scene(id, data, session):
     try:
-        session = Session()
         scene = (
             session.query(Scene)
             .filter(Scene.id == id)
             .update(data, synchronize_session="fetch")
         )
         session.commit()
-        session.close()
     except Exception as e:
         raise e
     return scene
 
 
 # TODO: move session creating and closing out of these individual calls
-def put_statistics(id, data):
+def put_statistics(id, data, session):
     try:
-        session = Session()
         statistics = (
             session.query(Statistics)
             .filter(Statistics.id == id)
             .update(data, synchronize_session="fetch")
         )
         session.commit()
-        session.close()
     except Exception as e:
         raise e
     return statistics
 
 
 # TODO: move session creating and closing out of these individual calls
-def put_text(id, data):
+def put_text(id, data, session):
     try:
-        session = Session()
         text = (
             session.query(Text)
             .filter(Text.id == id)
             .update(data, synchronize_session="fetch")
         )
         session.commit()
-        session.close()
     except Exception as e:
         raise e
     return text
 
 
-def delete_text(id):
+def delete_text(id, session):
     try:
-        session = Session()
-
         exists = session.query(Text).filter(Text.id == id).first() is not None
         if exists:
             session.query(Text).filter(Text.id == id).delete()
             session.commit()
 
-        session.close()
     except Exception as e:
         raise e
 

--- a/app/routes/admin/asset.py
+++ b/app/routes/admin/asset.py
@@ -23,7 +23,7 @@ class AdminAssetPostHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_asset_handler_body_schema)
 
-            inserted_asset = await post_asset_to_postgres(data)
+            inserted_asset = await post_asset_to_postgres(data, self.session)
 
             await self.finish(inserted_asset)
 
@@ -42,7 +42,7 @@ class AdminAssetHandler(BaseAdminAPIHandler):
         # Validate that id is valid
 
         try:
-            response_dict = await get_asset_from_postgres(id)
+            response_dict = await get_asset_from_postgres(id, self.session)
             await self.finish(response_dict)
 
         except ValueError:
@@ -54,7 +54,7 @@ class AdminAssetHandler(BaseAdminAPIHandler):
         # Validate that id is valid
 
         try:
-            response_message = await delete_asset_from_postgres(id)
+            response_message = await delete_asset_from_postgres(id, self.session)
             await self.finish(response_message)
 
         except ValueError as e:
@@ -71,7 +71,7 @@ class AdminAssetHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_asset_handler_body_schema)
 
-            response_message = await update_asset_from_postgres(id, data)
+            response_message = await update_asset_from_postgres(id, data, self.session)
             await self.finish(response_message)
 
         except ValueError as e:

--- a/app/routes/admin/object.py
+++ b/app/routes/admin/object.py
@@ -22,7 +22,7 @@ class AdminObjectPostHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_object_handler_schema)
 
-            inserted_obj = await post_object_to_postgres(scene_id, data)
+            inserted_obj = await post_object_to_postgres(scene_id, data, self.session)
 
             await self.finish(inserted_obj)
 
@@ -47,7 +47,7 @@ class AdminObjectPutHandler(BaseAdminAPIHandler):
             validate(data, schema=admin_object_handler_schema)
 
             response_message = await update_object_in_postgres(
-                scene_id, object_id, data
+                scene_id, object_id, data, self.session
             )
             await self.finish(response_message)
 
@@ -59,7 +59,9 @@ class AdminObjectPutHandler(BaseAdminAPIHandler):
     async def delete(self, scene_id, object_id):
 
         try:
-            response_message = await delete_object_in_postgres(scene_id, object_id)
+            response_message = await delete_object_in_postgres(
+                scene_id, object_id, self.session
+            )
             await self.finish(response_message)
 
         except ValueError as e:

--- a/app/routes/admin/scenario.py
+++ b/app/routes/admin/scenario.py
@@ -27,7 +27,7 @@ class AdminScenarioPostHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_scenario_post_handler_schema)
 
-            scenario_obj = await post_scenario_to_postgres(data)
+            scenario_obj = await post_scenario_to_postgres(data, self.session)
 
             await self.finish(scenario_obj)
 
@@ -46,7 +46,7 @@ class AdminScenarioHandler(BaseAdminAPIHandler):
         # Validate that id is valid
 
         try:
-            scenario_obj = await get_scenario_from_postgres(id)
+            scenario_obj = await get_scenario_from_postgres(id, self.session)
             await self.finish(scenario_obj)
 
         except ValueError as e:
@@ -58,7 +58,7 @@ class AdminScenarioHandler(BaseAdminAPIHandler):
         # Validate that id is valid
 
         try:
-            response_message = await delete_scenario_from_postgres(id)
+            response_message = await delete_scenario_from_postgres(id, self.session)
             await self.finish(response_message)
 
         except ValueError as e:
@@ -75,7 +75,9 @@ class AdminScenarioHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_scenario_put_handler_schema)
 
-            response_message = await update_scenario_from_postgres(id, data)
+            response_message = await update_scenario_from_postgres(
+                id, data, self.session
+            )
             await self.finish(response_message)
 
         except ValueError as e:
@@ -93,7 +95,7 @@ class AdminScenarioDuplicateHandler(BaseAdminAPIHandler):
 
         try:
 
-            response = await duplicate_scenario(id)
+            response = await duplicate_scenario(id, self.session)
 
             await self.finish(response)
 

--- a/app/routes/admin/scene.py
+++ b/app/routes/admin/scene.py
@@ -27,7 +27,7 @@ class AdminScenePostHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_scene_post_handler_schema)
 
-            id_inserted = await post_scene_to_postgres(data)
+            id_inserted = await post_scene_to_postgres(data, self.session)
 
             await self.finish({"id": id_inserted})
 
@@ -46,7 +46,7 @@ class AdminSceneHandler(BaseAdminAPIHandler):
         # Validate that id is valid
 
         try:
-            response_dict = await get_scene_from_postgres(id)
+            response_dict = await get_scene_from_postgres(id, self.session)
             await self.finish(response_dict)
 
         except ValueError:
@@ -63,7 +63,7 @@ class AdminSceneHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_scene_put_handler_schema)
 
-            response_message = await update_scene_from_postgres(id, data)
+            response_message = await update_scene_from_postgres(id, data, self.session)
             await self.finish(response_message)
 
         except ValueError as e:
@@ -75,7 +75,7 @@ class AdminSceneHandler(BaseAdminAPIHandler):
         # Validate that id is valid
 
         try:
-            response_message = await delete_scene_from_postgres(id)
+            response_message = await delete_scene_from_postgres(id, self.session)
             await self.finish(response_message)
 
         except ValueError as e:
@@ -93,7 +93,7 @@ class AdminSceneDuplicateHandler(BaseAdminAPIHandler):
 
         try:
 
-            response = await duplicate_scene(id)
+            response = await duplicate_scene(id, self.session)
 
             await self.finish(response)
 

--- a/app/routes/admin/text.py
+++ b/app/routes/admin/text.py
@@ -23,7 +23,7 @@ class AdminTextPostHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_text_handler_schema)
 
-            inserted_obj = await post_text_to_postgres(scene_id, data)
+            inserted_obj = await post_text_to_postgres(scene_id, data, self.session)
 
             await self.finish(inserted_obj)
 
@@ -42,7 +42,7 @@ class AdminTextHandler(BaseAdminAPIHandler):
         # Validate that id is valid
 
         try:
-            response_dict = await get_text_from_postgres(text_id)
+            response_dict = await get_text_from_postgres(text_id, self.session)
             await self.finish(response_dict)
 
         except ValueError as e:
@@ -59,7 +59,9 @@ class AdminTextHandler(BaseAdminAPIHandler):
             # validate body
             validate(data, schema=admin_text_handler_schema)
 
-            response_message = await put_text_to_postgres(scene_id, text_id, data)
+            response_message = await put_text_to_postgres(
+                scene_id, text_id, data, self.session
+            )
             await self.finish(response_message)
 
         except ValueError as e:

--- a/app/routes/base.py
+++ b/app/routes/base.py
@@ -2,12 +2,16 @@ from typing import Any
 
 import tornado.httputil as httputil
 import tornado.web
+from models import get_session, return_session
 
 
 class BaseAPIHandler(tornado.web.RequestHandler):
     """
     Base handler for all api/* routes
     """
+
+    def prepare(self):
+        self.session = get_session()
 
     def set_default_headers(self) -> None:
         self.set_header("Content-Type", "application/json")
@@ -19,6 +23,9 @@ class BaseAPIHandler(tornado.web.RequestHandler):
         self.set_status(status_code)
         response_error = {"status": status_code, "title": title, "message": message}
         self.finish(response_error)
+
+    def on_finish(self):
+        return_session(self.session)
 
 
 class BaseAdminAPIHandler(BaseAPIHandler):

--- a/app/routes/user/asset.py
+++ b/app/routes/user/asset.py
@@ -11,7 +11,7 @@ class UserAssetHandler(BaseUserAPIHandler):
         # Validate that id is valid
 
         try:
-            response_dict = await get_asset_from_postgres(id)
+            response_dict = await get_asset_from_postgres(id, self.session)
             await self.finish(response_dict)
 
         except ValueError:

--- a/app/routes/user/loading_screen.py
+++ b/app/routes/user/loading_screen.py
@@ -11,7 +11,7 @@ class UserLoadingScreen(BaseUserAPIHandler):
         # Validate that id is valid
 
         try:
-            response_dict = await get_loading_screen_from_postgres()
+            response_dict = await get_loading_screen_from_postgres(self.session)
             await self.finish(response_dict)
 
         except ValueError:

--- a/app/routes/user/scenario.py
+++ b/app/routes/user/scenario.py
@@ -11,7 +11,7 @@ class UserScenarioHandler(BaseUserAPIHandler):
         # Validate that id is valid
 
         try:
-            scenario_obj = await get_scenario_from_postgres(id)
+            scenario_obj = await get_scenario_from_postgres(id, self.session)
             await self.finish(scenario_obj)
 
         except ValueError as e:

--- a/app/routes/user/scene.py
+++ b/app/routes/user/scene.py
@@ -11,7 +11,7 @@ class UserSceneHandler(BaseUserAPIHandler):
         # Validate that id is valid
 
         try:
-            response_dict = await get_scene_from_postgres(id)
+            response_dict = await get_scene_from_postgres(id, self.session)
             await self.finish(response_dict)
 
         except ValueError:

--- a/app/routes/user/solved.py
+++ b/app/routes/user/solved.py
@@ -10,7 +10,7 @@ class UserSolvedHandler(BaseUserAPIHandler):
     async def get(self, id):
 
         try:
-            next_objects = await get_solved_from_postgres(id)
+            next_objects = await get_solved_from_postgres(id, self.session)
             await self.finish({"next_objects": next_objects})
 
         except ValueError:

--- a/app/routes/user/text.py
+++ b/app/routes/user/text.py
@@ -11,7 +11,7 @@ class UserTextHandler(BaseUserAPIHandler):
         # Validate that id is valid
 
         try:
-            response_dict = await get_text_from_postgres(id)
+            response_dict = await get_text_from_postgres(id, self.session)
             await self.finish(response_dict)
 
         except ValueError:


### PR DESCRIPTION
- Added limit to number of connections. Hard limit of 25 right now. Connection pool size is 20, so 20 connections will always be there, even when there is no activity at all.. just idling.
- And max_overflow of 5 means that an additional 5 connections may be created if needed but will be destroyed once done with, they will not be kept idle or reused.
- FIFO order by default

Based on these links mainly:
- https://docs.sqlalchemy.org/en/14/orm/session_basics.html#is-the-session-thread-safe ... it seems as long as a single session is not used across multiple threads, it is ok and the engine can handle it. But when 2 threads use the same session obj, then it is a concern. 
- https://docs.sqlalchemy.org/en/14/orm/contextual.html#unitofwork-contextual ... based on this there are a few ways to go about this, and the way we have it now, it seems to be using different sessions so we should not have any issues. 