### PR TITLE
Non-ordered Drag puzzles

### DIFF
--- a/samples/ordered_puzzle/components/ordered_puzzle.js
+++ b/samples/ordered_puzzle/components/ordered_puzzle.js
@@ -10,23 +10,24 @@ AFRAME.registerComponent("ordered-puzzle", {
 
   init: function () {
     const data = this.data.jsonData;
-
     const numPuzzlePieces = data.images.length;
-
     const puzzlePieceCache = [];
+    const blackboard = document.querySelector("#blackboard");
 
     for (i = 0; i < numPuzzlePieces; i++) {
-      var textBoxProp = data.images[i];
-      textBoxProp.color = "yellow";
+      if (data.useTargets) {
+        var textBoxProp = data.images[i];
+        textBoxProp.color = "yellow";
 
-      this.target = document.createElement("a-entity");
-      this.target.setAttribute("id", "puzzle-target-" + i);
-      this.target.setAttribute(
-        "target-box",
-        "jsonData",
-        JSON.stringify(textBoxProp)
-      );
-      this.el.appendChild(this.target);
+        this.target = document.createElement("a-entity");
+        this.target.setAttribute("id", "puzzle-target-" + i);
+        this.target.setAttribute(
+          "target-box",
+          "jsonData",
+          JSON.stringify(textBoxProp)
+        );
+        this.el.appendChild(this.target);
+      }
 
       this.puzzlePiece = document.createElement("a-image");
       this.puzzlePiece.setAttribute("id", "puzzle-piece-image-" + i);
@@ -35,18 +36,29 @@ AFRAME.registerComponent("ordered-puzzle", {
       this.puzzlePiece.setAttribute("height", data.images[i].height);
       this.puzzlePiece.setAttribute(
         "position",
-        data.images[i].x + " " + data.images[i].y + " 0"
+        (Math.random() - 0.5) *
+          (blackboard.getAttribute("geometry").width - data.images[i].width) +
+          " " +
+          (Math.random() - 0.5) *
+            (blackboard.getAttribute("geometry").height -
+              data.images[i].height) +
+          " 0"
       );
+      console.log(blackboard.getAttribute("geometry").width);
+      console.log(blackboard.object3D);
       this.puzzlePiece.setAttribute("xTarget", data.images[i].xTarget);
       this.puzzlePiece.setAttribute("yTarget", data.images[i].yTarget);
       this.puzzlePiece.setAttribute("onTarget", false);
       this.puzzlePiece.setAttribute("class", "draggable link");
-      this.puzzlePiece.addEventListener("dragend", function (event) {
-        event.target.setAttribute("onTarget", isOnTarget(event.target));
-        if (isPuzzleComplete(puzzlePieceCache)) {
-          closePuzzle();
-        }
-      });
+      if (data.useTargets) {
+        this.puzzlePiece.addEventListener("dragend", function (event) {
+          event.target.setAttribute("onTarget", isOnTarget(event.target));
+          if (isPuzzleComplete(puzzlePieceCache)) {
+            closePuzzle();
+          }
+        });
+      }
+
       this.el.appendChild(this.puzzlePiece);
       puzzlePieceCache.push(this.puzzlePiece);
     }

--- a/samples/ordered_puzzle/components/ordered_puzzle.js
+++ b/samples/ordered_puzzle/components/ordered_puzzle.js
@@ -35,7 +35,7 @@ AFRAME.registerComponent("ordered-puzzle", {
       this.puzzlePiece.setAttribute("width", data.images[i].width);
       this.puzzlePiece.setAttribute("height", data.images[i].height);
 
-      // Randomized the position of the puzzle piece on the blackboard
+      // Randomizes the position of the puzzle piece on the blackboard
       this.puzzlePiece.setAttribute(
         "position",
         (Math.random() - 0.5) *

--- a/samples/ordered_puzzle/components/ordered_puzzle.js
+++ b/samples/ordered_puzzle/components/ordered_puzzle.js
@@ -34,6 +34,8 @@ AFRAME.registerComponent("ordered-puzzle", {
       this.puzzlePiece.setAttribute("src", data.images[i].imageSrc);
       this.puzzlePiece.setAttribute("width", data.images[i].width);
       this.puzzlePiece.setAttribute("height", data.images[i].height);
+
+      // Randomized the position of the puzzle piece on the blackboard
       this.puzzlePiece.setAttribute(
         "position",
         (Math.random() - 0.5) *
@@ -44,8 +46,6 @@ AFRAME.registerComponent("ordered-puzzle", {
               data.images[i].height) +
           " 0"
       );
-      console.log(blackboard.getAttribute("geometry").width);
-      console.log(blackboard.object3D);
       this.puzzlePiece.setAttribute("xTarget", data.images[i].xTarget);
       this.puzzlePiece.setAttribute("yTarget", data.images[i].yTarget);
       this.puzzlePiece.setAttribute("onTarget", false);

--- a/samples/ordered_puzzle/ordered_puzzle.html
+++ b/samples/ordered_puzzle/ordered_puzzle.html
@@ -31,10 +31,10 @@
         <a-entity
           id="ordered-puzzle"
           ordered-puzzle='jsonData: {"images": [{"imageSrc" : "./images/pic1.png", "width": 3, "height": 3, "xTarget": -7, "yTarget": 0},
-          {"imageSrc" : "./images/pic2.png", "width": 3, "height": 3, "xTarget": -3.5, "yTarget": 0},
-          {"imageSrc" : "./images/pic3.png", "width": 3, "height": 3, "xTarget": 0, "yTarget": 0},
-          {"imageSrc" : "./images/pic4.png", "width": 3, "height": 3, "xTarget": 3.5, "yTarget": 0},
-          {"imageSrc" : "./images/pic5.png", "width": 3, "height": 3, "xTarget": 7, "yTarget": 0}],
+          {"imageSrc" : "./images/pic2.png", "width": 3, "height": 3},
+          {"imageSrc" : "./images/pic3.png", "width": 3, "height": 3},
+          {"imageSrc" : "./images/pic4.png", "width": 3, "height": 3},
+          {"imageSrc" : "./images/pic5.png", "width": 3, "height": 3}],
           "useTargets": false}'
         ></a-entity>
       </a-entity>

--- a/samples/ordered_puzzle/ordered_puzzle.html
+++ b/samples/ordered_puzzle/ordered_puzzle.html
@@ -30,11 +30,12 @@
         ></a-entity>
         <a-entity
           id="ordered-puzzle"
-          ordered-puzzle='jsonData: {"images": [{"imageSrc" : "./images/pic1.png", "width": 3, "height": 3, "xTarget": -7, "yTarget": 0, "x": 0, "y": 4},
-          {"imageSrc" : "./images/pic2.png", "width": 3, "height": 3, "xTarget": -3.5, "yTarget": 0, "x": -2, "y": -4},
-          {"imageSrc" : "./images/pic3.png", "width": 3, "height": 3, "xTarget": 0, "yTarget": 0, "x": -4, "y": 4},
-          {"imageSrc" : "./images/pic4.png", "width": 3, "height": 3, "xTarget": 3.5, "yTarget": 0, "x": 2, "y": -4},
-          {"imageSrc" : "./images/pic5.png", "width": 3, "height": 3, "xTarget": 7, "yTarget": 0, "x": 4, "y": 4}]}'
+          ordered-puzzle='jsonData: {"images": [{"imageSrc" : "./images/pic1.png", "width": 3, "height": 3, "xTarget": -7, "yTarget": 0},
+          {"imageSrc" : "./images/pic2.png", "width": 3, "height": 3, "xTarget": -3.5, "yTarget": 0},
+          {"imageSrc" : "./images/pic3.png", "width": 3, "height": 3, "xTarget": 0, "yTarget": 0},
+          {"imageSrc" : "./images/pic4.png", "width": 3, "height": 3, "xTarget": 3.5, "yTarget": 0},
+          {"imageSrc" : "./images/pic5.png", "width": 3, "height": 3, "xTarget": 7, "yTarget": 0}],
+          "useTargets": false}'
         ></a-entity>
       </a-entity>
     </a-scene>

--- a/samples/ordered_puzzle/ordered_puzzle.html
+++ b/samples/ordered_puzzle/ordered_puzzle.html
@@ -31,11 +31,11 @@
         <a-entity
           id="ordered-puzzle"
           ordered-puzzle='jsonData: {"images": [{"imageSrc" : "./images/pic1.png", "width": 3, "height": 3, "xTarget": -7, "yTarget": 0},
-          {"imageSrc" : "./images/pic2.png", "width": 3, "height": 3},
-          {"imageSrc" : "./images/pic3.png", "width": 3, "height": 3},
-          {"imageSrc" : "./images/pic4.png", "width": 3, "height": 3},
-          {"imageSrc" : "./images/pic5.png", "width": 3, "height": 3}],
-          "useTargets": false}'
+          {"imageSrc" : "./images/pic2.png", "width": 3, "height": 3, "xTarget": -3.5, "yTarget": 0},
+          {"imageSrc" : "./images/pic3.png", "width": 3, "height": 3, "xTarget": 0, "yTarget": 0},
+          {"imageSrc" : "./images/pic4.png", "width": 3, "height": 3, "xTarget": 3.5, "yTarget": 0},
+          {"imageSrc" : "./images/pic5.png", "width": 3, "height": 3, "xTarget": 7, "yTarget": 0}],
+          "useTargets": true}'
         ></a-entity>
       </a-entity>
     </a-scene>


### PR DESCRIPTION
This PR generalizes the ordered puzzles component to have a flag that can either enable or disable targets/order validation for puzzles. Images provided by admin are randomly populated on the blackboard and can be freely moved around.

https://www.loom.com/share/59d824b95a894f0a86f2e999a9329b97