### PR TITLE
Allowing arbitrary options arguments and specifying methods

### DIFF
--- a/app/routes/base.py
+++ b/app/routes/base.py
@@ -34,7 +34,7 @@ class BaseAdminAPIHandler(BaseAPIHandler):
     Base handler for all api/admin/* routes
     """
 
-    async def options(self):
+    async def options(self, *args):
         self.set_status(204)
         await self.finish()
 
@@ -43,6 +43,9 @@ class BaseAdminAPIHandler(BaseAPIHandler):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header(
             "Access-Control-Allow-Headers", "x-requested-with, content-type"
+        )
+        self.set_header(
+            "Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS"
         )
 
     def prepare(self):


### PR DESCRIPTION
- PUT requests from Axios issues an OPTIONS request before the PUT requests. This causes two problems:
    - Our current base implementation of OPTIONS only allows one argument, but we did not account for requests that have multiple arguments (as is the case for PUT)
    - Axios will only allow requests from the Access-Control-Allow-Methods that is returned from OPTIONS, which currently bars PUT requests

- The above issues are resolved in this PR (discussed with @jaydhulia)