### PR TITLE
Fix delete scene request + mock data issues on object level

### DIFF
--- a/app/library/postgres.py
+++ b/app/library/postgres.py
@@ -213,11 +213,10 @@ async def delete_scene_from_postgres(scene_id: str, session):
     scenarios = get_scenarios(session)
     for scenario in scenarios:
         if int(scene_id) in scenario.scene_ids:
-            scenario_obj: Scenario = await get_scenario_from_postgres(
-                scenario.id, session
+            scenario.scene_ids.remove(int(scene_id))
+            await update_scenario_from_postgres(
+                scenario.id, scenario.as_dict(), session
             )
-            scenario_obj["scene_ids"].remove(int(scene_id))
-            await update_scenario_from_postgres(scenario.id, scenario_obj, session)
 
     response = {"message": "Deleted successfully"}
     return response

--- a/app/library/postgres.py
+++ b/app/library/postgres.py
@@ -209,6 +209,16 @@ async def delete_scene_from_postgres(scene_id: str, session):
     if not delete_scene(scene_id, session):
         raise ValueError("Scene ID not valid")
 
+    # Remove the scene from scenario's scene_ids array
+    scenarios = get_scenarios(session)
+    for scenario in scenarios:
+        if int(scene_id) in scenario.scene_ids:
+            scenario_obj: Scenario = await get_scenario_from_postgres(
+                scenario.id, session
+            )
+            scenario_obj["scene_ids"].remove(int(scene_id))
+            await update_scenario_from_postgres(scenario.id, scenario_obj, session)
+
     response = {"message": "Deleted successfully"}
     return response
 

--- a/scripts/mockdata/objects.json
+++ b/scripts/mockdata/objects.json
@@ -301,5 +301,143 @@
         }
       }
     }
+  },
+  {
+    "name": "Classroom rotation inspector",
+    "position": [0, 0.014, -5.717],
+    "scale": [1, 1, 1],
+    "rotation": [0, 0, 0],
+    "asset_id": 1,
+    "next_objects": [
+      {
+        "id": 2,
+        "action": {
+          "type": "text",
+          "text_id": 1
+        }
+      }
+    ],
+    "texts": ["", "hello", "from the other side"],
+    "is_interactable": true,
+    "animations_json": {
+      "blackboardData": {
+        "componentType": "rotation-controls",
+        "jsonData": {
+          "position": [0, 0, 5]
+        }
+      }
+    }
+  },
+  {
+    "name": "Classroom keypad",
+    "position": [4.487, 1.435, -4.129],
+    "scale": [0.05, 0.05, 0.05],
+    "rotation": [-90.0, 180.0, 180.0],
+    "asset_id": 3,
+    "next_objects": [
+      {
+        "id": 3,
+        "action": {
+          "type": "class",
+          "interactive": true
+        }
+      },
+      {
+        "id": 3,
+        "action": {
+          "type": "text",
+          "text_id": 2
+        }
+      },
+      {
+        "id": 1,
+        "action": {
+          "type": "text",
+          "text_id": 3
+        }
+      }
+    ],
+    "texts": ["", "hello", "kenobi"],
+    "is_interactable": true,
+    "animations_json": {
+      "blackboardData": {
+        "componentType": "keypad",
+        "jsonData": {
+          "password": "1234",
+          "model": "numpad",
+          "is_last_object": true
+        }
+      }
+    }
+  },
+  {
+    "name": "Classroom keyboard",
+    "position": [5.775, 0.014, -5.717],
+    "scale": [1, 1, 1],
+    "rotation": [0, 0, 0],
+    "asset_id": 1,
+    "next_objects": [
+      {
+        "id": 2,
+        "action": {
+          "type": "text",
+          "text_id": 1
+        }
+      }
+    ],
+    "texts": ["", "hello", "from the other side part 2"],
+    "is_interactable": true,
+    "animations_json": {
+      "blackboardData": {
+        "componentType": "keypad",
+        "jsonData": {
+          "password": "abcde",
+          "model": "basic",
+          "is_last_object": true
+        }
+      }
+    }
+  },
+  {
+    "name": "Classroom keypad",
+    "position": [4.487, 1.435, -4.129],
+    "scale": [0.05, 0.05, 0.05],
+    "rotation": [-90.0, 180.0, 180.0],
+    "asset_id": 3,
+    "next_objects": [
+      {
+        "id": 3,
+        "action": {
+          "type": "class",
+          "interactive": true
+        }
+      },
+      {
+        "id": 3,
+        "action": {
+          "type": "text",
+          "text_id": 2
+        }
+      },
+      {
+        "id": 1,
+        "action": {
+          "type": "text",
+          "text_id": 3
+        }
+      }
+    ],
+    "texts": ["", "hello", "kenobi"],
+    "is_interactable": true,
+    "animations_json": {
+      "blackboardData": {
+        "componentType": "keypad",
+        "jsonData": {
+          "password": "1234",
+          "model": "numpad",
+          "is_last_object": true
+        }
+      }
+    }
   }
 ]

--- a/scripts/mockdata/objects.json
+++ b/scripts/mockdata/objects.json
@@ -303,7 +303,7 @@
     }
   },
   {
-    "name": "Classroom rotation inspector",
+    "name": "Student bedroom rotation inspector",
     "position": [0, 0.014, -5.717],
     "scale": [1, 1, 1],
     "rotation": [0, 0, 0],
@@ -329,7 +329,7 @@
     }
   },
   {
-    "name": "Classroom keypad",
+    "name": "Student bedroom keypad",
     "position": [4.487, 1.435, -4.129],
     "scale": [0.05, 0.05, 0.05],
     "rotation": [-90.0, 180.0, 180.0],
@@ -371,7 +371,7 @@
     }
   },
   {
-    "name": "Classroom keyboard",
+    "name": "Student bedroom keyboard",
     "position": [5.775, 0.014, -5.717],
     "scale": [1, 1, 1],
     "rotation": [0, 0, 0],
@@ -393,48 +393,6 @@
         "jsonData": {
           "password": "abcde",
           "model": "basic",
-          "is_last_object": true
-        }
-      }
-    }
-  },
-  {
-    "name": "Classroom keypad",
-    "position": [4.487, 1.435, -4.129],
-    "scale": [0.05, 0.05, 0.05],
-    "rotation": [-90.0, 180.0, 180.0],
-    "asset_id": 3,
-    "next_objects": [
-      {
-        "id": 3,
-        "action": {
-          "type": "class",
-          "interactive": true
-        }
-      },
-      {
-        "id": 3,
-        "action": {
-          "type": "text",
-          "text_id": 2
-        }
-      },
-      {
-        "id": 1,
-        "action": {
-          "type": "text",
-          "text_id": 3
-        }
-      }
-    ],
-    "texts": ["", "hello", "kenobi"],
-    "is_interactable": true,
-    "animations_json": {
-      "blackboardData": {
-        "componentType": "keypad",
-        "jsonData": {
-          "password": "1234",
-          "model": "numpad",
           "is_last_object": true
         }
       }

--- a/scripts/mockdata/scenes.json
+++ b/scripts/mockdata/scenes.json
@@ -2,7 +2,7 @@
   {
     "name": "Student Bedroom",
     "description": "A standard student bedroom. Twin size bed, small table for school work, small closet.",
-    "object_ids": [1, 2, 3],
+    "object_ids": [9, 10, 11],
     "position": [0.1, 0.5, 0.1],
     "scale": [1.0, 1.0, 1.0],
     "rotation": [0.1, 0.5, 0.1],
@@ -26,7 +26,7 @@
   {
     "name": "Living Room",
     "description": "A standard master bedroom. King size bed, a dresser, ensuit washroom, and a large closet.",
-    "object_ids": [2],
+    "object_ids": [12],
     "position": [0, 0.13, 0],
     "scale": [1.0, 1.0, 1.0],
     "rotation": [0.0, 0.0, 0.0],

--- a/scripts/mockdata/scenes.json
+++ b/scripts/mockdata/scenes.json
@@ -26,7 +26,7 @@
   {
     "name": "Living Room",
     "description": "A standard master bedroom. King size bed, a dresser, ensuit washroom, and a large closet.",
-    "object_ids": [12],
+    "object_ids": [2],
     "position": [0, 0.13, 0],
     "scale": [1.0, 1.0, 1.0],
     "rotation": [0.0, 0.0, 0.0],


### PR DESCRIPTION
When a scene was deleted it was not also removed from the scene_ids array on the scenario level. So when a subsequent fetch was made for the scenes, we would get an error. Also, the mock data for objects was not properly setup since we do not allow same objects in multiple rooms, so when a scene is deleted so are all the nested objects, but then that causes issues for the scene since its objects are deleted. Made them independent on mock data.