### PR TITLE
Update schema validations to include numbers

### DIFF
--- a/app/library/api_schemas.py
+++ b/app/library/api_schemas.py
@@ -5,7 +5,7 @@ from config import config
 admin_asset_handler_body_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
         "obj_type": {
             "enum": config.get("asset.allowed_asset_types"),
         },
@@ -18,8 +18,8 @@ admin_asset_handler_body_schema = {
 admin_scenario_post_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z _-]{1,50}$"},
-        "friendly_name": {"type": "string", "pattern": r"^[a-zA-Z_-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
+        "friendly_name": {"type": "string", "pattern": r"^[a-zA-Z0-9_-]{1,50}$"},
         "description": {"type": "string", "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$"},
     },
     "required": [
@@ -29,11 +29,12 @@ admin_scenario_post_handler_schema = {
     ],
     "additionalProperties": False,
 }
+
 admin_scenario_put_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z _-]{1,50}$"},
-        "friendly_name": {"type": "string", "pattern": r"^[a-zA-Z_-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
+        "friendly_name": {"type": "string", "pattern": r"^[a-zA-Z0-9_-]{1,50}$"},
         "description": {"type": "string", "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$"},
         "scene_ids": {"type": "array", "items": {"type": "integer"}},
         "is_published": {"type": "boolean"},
@@ -79,7 +80,7 @@ admin_scenario_put_handler_schema = {
 admin_scene_post_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
         "background_id": {"type": "integer"},
         "description": {"type": "string", "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$"},
     },
@@ -93,7 +94,7 @@ admin_scene_post_handler_schema = {
 admin_scene_put_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
         "description": {"type": "string", "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$"},
         "object_ids": {"type": "array", "items": {"type": "integer"}},
         "position": {"type": "array", "items": {"type": "number"}},
@@ -102,7 +103,7 @@ admin_scene_put_handler_schema = {
         "background_id": {"type": "integer"},
         "hints": {
             "type": "array",
-            "items": {"type": "string", "pattern": r"^[\:\?\!\.,a-zA-Z _-]{1,200}$"},
+            "items": {"type": "string", "pattern": r"^[\:\?\!\.,a-zA-Z0-9 _-]{1,200}$"},
         },
         "camera_properties": {
             "type": "object",


### PR DESCRIPTION
When going through API integration from the frontend, I would be trying to name a room "Escape Room 2" and it would fail due to the lack of allowing numbers. I think numbers should be allowed since this is a very viable name that DCC admins might use.

As a future point, things like apostrophes should also be supported, if I want to do "Billy's Room" or something along those lines.