### PR TITLE
Save the changes required for enabling https info

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.9.1
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.7.0

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -132,10 +132,19 @@ def main():
 
     app = make_app()
     init_firebase()
-    server = tornado.httpserver.HTTPServer(app)
 
     port = config.get("tornado.port")
-    if port:
+    if port == 443:
+        server = tornado.httpserver.HTTPServer(
+            app,
+            ssl_options={
+                "certfile": f"{os.path.dirname(__file__)}/../secrets/domain.crt",
+                "keyfile": f"{os.path.dirname(__file__)}/../secrets/domain.key",
+            },
+        )
+        server.bind(port, address=config.get("tornado.address"))
+    else:
+        server = tornado.httpserver.HTTPServer(app)
         server.bind(port, address=config.get("tornado.address"))
 
     server.start()


### PR DESCRIPTION
- Doesn't affect the regular workflow, but saving the changes needed to enable https from Tornado side.
- Also removing the language version of black since it isn't needed