### PR TITLE
Text header for blackboard.

### DIFF
--- a/app/public/static/js/components/animation-on-click.js
+++ b/app/public/static/js/components/animation-on-click.js
@@ -35,8 +35,8 @@ AFRAME.registerComponent("animation-on-click-run", {
 
 // TODO: Add support for multiple entity creation
 function addEntityToBlackboard(componentDataParsed) {
-  var blackboardEl = document.querySelector("#blackboard");
-  var entityEl = document.createElement("a-entity");
+  let blackboardEl = document.querySelector("#blackboard");
+  let entityEl = document.createElement("a-entity");
   entityEl.setAttribute(
     componentDataParsed.componentType,
     "jsonData",
@@ -49,9 +49,33 @@ function addEntityToBlackboard(componentDataParsed) {
 
   entityEl.addEventListener("loaded", function (e) {
     if (e.target === entityEl) {
-      var popupCameraEl = document.querySelector("#popup-camera");
+      let popupCameraEl = document.querySelector("#popup-camera");
       popupCameraEl.setAttribute("camera", "active", true);
       // Puzzle types that are draggable
+      if (componentDataParsed.hasOwnProperty("blackboardText")) {
+        let blackboardTextEl = document.querySelector("#blackboardText");
+        const blackboardText = componentDataParsed.blackboardText;
+        const blackboardTextColor = componentDataParsed.hasOwnProperty(
+          "blackboardTextColor"
+        )
+          ? componentDataParsed.blackboardTextColor
+          : "white";
+
+        // Without this, the text might be too large or small. The values can be adjusted if needed.
+        const blackboardTextWidth = blackboardTextEl.getAttribute("text").width;
+        const textWrapCount = Math.max(
+          Math.min(blackboardText.length, 60),
+          blackboardTextWidth + 5
+        );
+
+        blackboardTextEl.setAttribute("text", {
+          color: blackboardTextColor,
+          width: blackboardTextWidth,
+          wrapCount: textWrapCount,
+          value: blackboardText,
+        });
+      }
+
       if (
         componentDataParsed.hasOwnProperty("draggable") &&
         componentDataParsed.draggable

--- a/app/public/static/js/components/close-popup.js
+++ b/app/public/static/js/components/close-popup.js
@@ -63,6 +63,8 @@ async function closePopup(numSeconds, is_last_object, el) {
 
 function wipeBlackboard() {
   let blackboardEl = document.querySelector("#blackboard");
+  let blackbaordTextEl = document.querySelector("#blackboardText");
+  blackbaordTextEl.setAttribute("text", "value", "");
   while (blackboardEl.firstChild) {
     blackboardEl.removeChild(blackboardEl.lastChild);
   }

--- a/app/public/static/js/components/keypad.js
+++ b/app/public/static/js/components/keypad.js
@@ -15,6 +15,7 @@ AFRAME.registerComponent("keypad", {
     const password = data.password;
     const el = this.el;
     this.id = data.id;
+    let self = this;
     let is_last_object = false;
     if ("is_last_object" in data) {
       is_last_object = data.is_last_object;
@@ -41,11 +42,19 @@ AFRAME.registerComponent("keypad", {
       } else {
         const statusLabel = el.getAttribute("super-keyboard").label;
         if (statusLabel !== "SUCCESS") {
-          el.setAttribute("super-keyboard", {
-            label: "ERROR",
-            labelColor: "red",
+          let blackboardTextEl = document.querySelector("#blackboardText");
+          if (!self.data.hasOwnProperty("prevTextEl")) {
+            // only get value the first time.
+            self.data.prevTextEl = JSON.parse(
+              JSON.stringify(blackboardTextEl.getAttribute("text"))
+            );
+          }
+          blackboardTextEl.setAttribute("text", {
+            value: "ERROR",
+            color: "red",
+            wrapCount: "20",
           });
-          removeError(el);
+          removeError(self);
         }
       }
     });
@@ -83,27 +92,45 @@ AFRAME.registerComponent("keypad", {
       // not loaded yet, do nothing
     } else if (this.puzzleIsSolved === true) {
       // Already solved
+      let blackboardTextEl = document.querySelector("#blackboardText");
+      if (!this.data.hasOwnProperty("prevTextEl")) {
+        // only get value the first time.
+        this.data.prevTextEl = JSON.parse(
+          JSON.stringify(blackboardTextEl.getAttribute("text"))
+        );
+      }
+      blackboardTextEl.setAttribute("text", {
+        value: "SUCCESS",
+        color: "green",
+        wrapCount: "20",
+      });
       el.setAttribute("super-keyboard", {
-        label: "SUCCESS",
-        labelColor: "green",
         multipleInputs: true,
       });
       this.solvedPuzzleEntity.setAttribute("visible", "true");
     } else {
       // Not solved yet
-      el.setAttribute("super-keyboard", {
-        label: "Enter Password",
-        labelColor: "black",
-      });
+      let blackboardTextEl = document.querySelector("#blackboardText");
+      if (this.data.hasOwnProperty("prevTextEl")) {
+        blackboardTextEl.setAttribute("text", this.data.prevTextEl);
+      }
     }
   },
 });
 
-async function removeError(el) {
+async function removeError(self) {
   setTimeout(function () {
-    el.setAttribute("super-keyboard", {
-      label: "Enter Password",
-      labelColor: "black",
-    });
+    if (!self.puzzleIsSolved) {
+      let blackboardTextEl = document.querySelector("#blackboardText");
+      if (self.data.hasOwnProperty("prevTextEl")) {
+        blackboardTextEl.setAttribute("text", self.data.prevTextEl);
+      } else {
+        blackboardTextEl.setAttribute("text", {
+          value: "",
+          color: "white",
+          wrapCount: "20",
+        });
+      }
+    }
   }, 1.5 * 1000);
 }

--- a/app/public/templates/popup.html
+++ b/app/public/templates/popup.html
@@ -11,6 +11,10 @@
     close-popup='jsonData: {"width": "1", "height": "1", "depth": "0.01", "color": "red", "x": "-8.25", "y": "6.75", "z": "0.005"};'
     class="link"
   ></a-entity>
+    <a-entity
+    id="blackboardText"
+    text="align: center; width: 15;"
+    position="0 6 0.005"></a-entity>
   <a-entity
     id="popup-camera"
     position="0 0 9"

--- a/scripts/mockdata/objects.json
+++ b/scripts/mockdata/objects.json
@@ -59,6 +59,7 @@
     "animations_json": {
       "blackboardData": {
         "componentType": "keypad",
+        "blackboardText": "Enter PIN:",
         "jsonData": {
           "password": "1234",
           "model": "numpad",
@@ -87,6 +88,8 @@
     "animations_json": {
       "blackboardData": {
         "componentType": "keypad",
+        "blackboardText": "Enter Password:",
+        "blackboardTextColor": "white",
         "jsonData": {
           "password": "abcde",
           "model": "basic",


### PR DESCRIPTION
For any blackboard object, this will work. Currently text and color can be modified. Color is white by default.
The text will show on the top of the puzzles. It will auto resize based on the amount of text and wrap around if needed. About 25-30 words is the limit right now before we overflow off the cameraview.

Below are different scenarios of the blackboard puzzles. 

![image](https://user-images.githubusercontent.com/35475783/121466926-35c78180-c986-11eb-8682-740e0fe78584.png)
![image](https://user-images.githubusercontent.com/35475783/121466930-36601800-c986-11eb-8688-3da19120ec22.png)
![image](https://user-images.githubusercontent.com/35475783/121467058-6f988800-c986-11eb-9887-b9913736f3ef.png)
![image](https://user-images.githubusercontent.com/35475783/121467311-dcac1d80-c986-11eb-8cb9-9a3996c11b4c.png)

