### PR TITLE
Allow apostrophes in name/description fields

### DIFF
--- a/app/library/api_schemas.py
+++ b/app/library/api_schemas.py
@@ -5,7 +5,7 @@ from config import config
 admin_asset_handler_body_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[\'a-zA-Z0-9 _-]{1,50}$"},
         "obj_type": {
             "enum": config.get("asset.allowed_asset_types"),
         },
@@ -18,11 +18,11 @@ admin_asset_handler_body_schema = {
 admin_scenario_post_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[\'a-zA-Z0-9 _-]{1,50}$"},
         "friendly_name": {"type": "string", "pattern": r"^[a-zA-Z0-9_-]{1,50}$"},
         "description": {
             "type": "string",
-            "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$",
+            "pattern": r"^[\'\?\!\.,a-zA-Z0-9 _-]{,2000}$",
         },
     },
     "required": [
@@ -36,9 +36,12 @@ admin_scenario_post_handler_schema = {
 admin_scenario_put_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[\'a-zA-Z0-9 _-]{1,50}$"},
         "friendly_name": {"type": "string", "pattern": r"^[a-zA-Z0-9_-]{1,50}$"},
-        "description": {"type": "string", "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$"},
+        "description": {
+            "type": "string",
+            "pattern": r"^[\'\?\!\.,a-zA-Z0-9 _-]{,2000}$",
+        },
         "scene_ids": {"type": "array", "items": {"type": "integer"}},
         "is_published": {"type": "boolean"},
         "is_previewable": {"type": "boolean"},
@@ -99,9 +102,12 @@ admin_scenario_put_handler_schema = {
 admin_scene_post_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[\'a-zA-Z0-9 _-]{1,50}$"},
         "background_id": {"type": "integer"},
-        "description": {"type": "string", "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$"},
+        "description": {
+            "type": "string",
+            "pattern": r"^[\'\?\!\.,a-zA-Z0-9 _-]{,2000}$",
+        },
     },
     "required": [
         "name",
@@ -113,8 +119,11 @@ admin_scene_post_handler_schema = {
 admin_scene_put_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
-        "description": {"type": "string", "pattern": r"^[\?\!\.,a-zA-Z0-9 _-]{,2000}$"},
+        "name": {"type": "string", "pattern": r"^[\'a-zA-Z0-9 _-]{1,50}$"},
+        "description": {
+            "type": "string",
+            "pattern": r"^[\'\?\!\.,a-zA-Z0-9 _-]{,2000}$",
+        },
         "object_ids": {"type": "array", "items": {"type": "integer"}},
         "position": {"type": "array", "items": {"type": "number"}},
         "scale": {"type": "array", "items": {"type": "number"}},
@@ -161,7 +170,7 @@ admin_scene_put_handler_schema = {
 admin_object_handler_schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string", "pattern": r"^[a-zA-Z0-9 _-]{1,50}$"},
+        "name": {"type": "string", "pattern": r"^[\'a-zA-Z0-9 _-]{1,50}$"},
         "position": {"type": "array", "items": {"type": "number"}},
         "scale": {"type": "array", "items": {"type": "number"}},
         "rotation": {"type": "array", "items": {"type": "number"}},


### PR DESCRIPTION
In the mock data (as per #132), a single quote was added to the description field of a room (which makes sense).

However, the handlers for this do not accept this, so when I was changing the order of rooms on the frontend, I would get an error.

Updated the validation to allow for apostrophes.