### PR TITLE
Delete puzzle assets from S3

### DIFF
--- a/app/library/postgres.py
+++ b/app/library/postgres.py
@@ -465,26 +465,32 @@ async def clean_object_assets_from_aws(old: dict, new: dict):
     if old_puzzle_type == "jigsaw-puzzle":
         # jigsaw puzzle always requires cleanup due to the way it is setup
         for img in old_obj.animations_json["blackboardData"]["jsonData"]["images"]:
-            keys_to_delete.append(img.split("amazonaws.com/")[-1])
+            keys_to_delete.append({"Key": img.split("amazonaws.com/")[-1]})
     elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "visual-pane":
         keys_to_delete.append(
-            old_obj.animations_json["blackboardData"]["jsonData"]["imageSrc"].split(
-                "amazonaws.com/"
-            )[-1]
+            {
+                "Key": old_obj.animations_json["blackboardData"]["jsonData"][
+                    "imageSrc"
+                ].split("amazonaws.com/")[-1]
+            }
         )
     elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "text-pane":
         for elem in old_obj.animations_json["blackboardData"]["jsonData"]["data"]:
             if "imageSrc" in elem:
-                keys_to_delete.append(elem["imageSrc"].split("amazonaws.com/")[-1])
+                keys_to_delete.append(
+                    {"Key": elem["imageSrc"].split("amazonaws.com/")[-1]}
+                )
     elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "ordered-puzzle":
         for elem in old_obj.animations_json["blackboardData"]["jsonData"]["images"]:
-            keys_to_delete.append(elem["imageSrc"].split("amazonaws.com/")[-1])
+            keys_to_delete.append({"Key": elem["imageSrc"].split("amazonaws.com/")[-1]})
 
-    # s3_client = boto3.client(
-    #     "s3",
-    #     endpoint_url=f"https://s3.{config.get('s3.region')}.amazonaws.com",
-    #     region_name=config.get("s3.region"),
-    # )
-    # TODO: actual delete
-
-    print(f"To be deleted: {keys_to_delete}")
+    # Only delete if hard delete is set to True
+    if config.get("asset.aws_hard_delete", False) and len(keys_to_delete) > 0:
+        s3_client = boto3.client(
+            "s3",
+            endpoint_url=f"https://s3.{config.get('s3.region')}.amazonaws.com",
+            region_name=config.get("s3.region"),
+        )
+        s3_client.delete_objects(
+            Bucket=config.get("s3.bucket_name"), Delete={"Objects": keys_to_delete}
+        )

--- a/app/library/postgres.py
+++ b/app/library/postgres.py
@@ -473,7 +473,7 @@ async def clean_object_assets_from_aws(old: dict, new: dict):
             )[-1]
         )
     elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "text-pane":
-        for elem in old_obj.animations_json["blackboardData"]["jsonData"]["images"]:
+        for elem in old_obj.animations_json["blackboardData"]["jsonData"]["data"]:
             if "imageSrc" in elem:
                 keys_to_delete.append(elem["imageSrc"].split("amazonaws.com/")[-1])
     elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "ordered-puzzle":

--- a/app/library/postgres.py
+++ b/app/library/postgres.py
@@ -462,7 +462,8 @@ async def clean_object_assets_from_aws(old: dict, new: dict):
         # new obj isn't intractable and old object was... need to clean up for certain puzzle types
         new_puzzle_type = new_obj.animations_json["blackboardData"]["componentType"]
     keys_to_delete = []
-    if old_puzzle_type != new_puzzle_type and old_puzzle_type == "jigsaw-puzzle":
+    if old_puzzle_type == "jigsaw-puzzle":
+        # jigsaw puzzle always requires cleanup due to the way it is setup
         for img in old_obj.animations_json["blackboardData"]["jsonData"]["images"]:
             keys_to_delete.append(img.split("amazonaws.com/")[-1])
     elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "visual-pane":
@@ -471,7 +472,13 @@ async def clean_object_assets_from_aws(old: dict, new: dict):
                 "amazonaws.com/"
             )[-1]
         )
-    # TODO: elif text-pane, ordered-puzzle, unordered-puzzle
+    elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "text-pane":
+        for elem in old_obj.animations_json["blackboardData"]["jsonData"]["images"]:
+            if "imageSrc" in elem:
+                keys_to_delete.append(elem["imageSrc"].split("amazonaws.com/")[-1])
+    elif old_puzzle_type != new_puzzle_type and old_puzzle_type == "ordered-puzzle":
+        for elem in old_obj.animations_json["blackboardData"]["jsonData"]["images"]:
+            keys_to_delete.append(elem["imageSrc"].split("amazonaws.com/")[-1])
 
     # s3_client = boto3.client(
     #     "s3",

--- a/app/library/postgres.py
+++ b/app/library/postgres.py
@@ -444,10 +444,8 @@ async def delete_object_in_postgres(scene_id: str, object_id: str, session):
 
 
 async def clean_object_assets_from_aws(old: dict, new: dict):
-    # Only delete from AWS if config is enabled for AWS support
-    # TODO: uncomment
-    # if "aws" not in config.get("app-env"):
-    #     return
+    if "aws" not in config.get("app-env"):
+        return
     del old["asset_details"]
     del new["asset_details"]
     old_obj = Object(**old)

--- a/app/routes/admin/object.py
+++ b/app/routes/admin/object.py
@@ -2,6 +2,7 @@ import tornado.escape
 from jsonschema import validate
 from library.api_schemas import admin_object_handler_schema, admin_puzzle_handler_schema
 from library.postgres import (
+    clean_object_assets_from_aws,
     delete_object_in_postgres,
     get_object_from_postgres,
     post_object_to_postgres,
@@ -98,10 +99,12 @@ class AdminPuzzleHandler(BaseAdminAPIHandler):
 
             # validate body
             validate(data, schema=admin_puzzle_handler_schema)
-
+            saved_object = await get_object_from_postgres(object_id, self.db_session)
             response_message = await update_object_in_postgres(
                 scene_id, object_id, data, self.db_session
             )
+            await clean_object_assets_from_aws(saved_object, response_message)
+
             await self.finish(response_message)
 
         except ValueError as e:


### PR DESCRIPTION
- When an object changes from interactable -> non-interactable, OR it's puzzle type changes, we should clean up the old assets from S3 related to the old object