### PR TITLE
Change landing page verbiage

### DIFF
--- a/app/public/templates/home.html
+++ b/app/public/templates/home.html
@@ -50,7 +50,7 @@
       </nav>
       {% if len(res_scenarios) == 0 %}
       <h2>No escape rooms found</h2>
-      {% else %} {% if len(res_scenarios) > 1 %}
+      {% elif len(res_scenarios) > 1 %}
       <h2>Try out one of the escape rooms below!</h2>
       {% else %}
       <h2>Try out the escape room below!</h2>
@@ -64,7 +64,7 @@
           >
         </div>
       </div>
-      {% end %} {% end %}
+      {% end %}
     </div>
   </body>
 </html>

--- a/app/public/templates/home.html
+++ b/app/public/templates/home.html
@@ -48,9 +48,13 @@
           alt=""
         />
       </nav>
-      {% if len(res_scenarios) > 0 %}
-      <h1>Try out one of the escape rooms below!</h1>
-      {% for scenario in res_scenarios %}
+      {% if len(res_scenarios) == 0 %}
+      <h2>No escape rooms found</h2>
+      {% else %} {% if len(res_scenarios) > 1 %}
+      <h2>Try out one of the escape rooms below!</h2>
+      {% else %}
+      <h2>Try out the escape room below!</h2>
+      {% end %} {% for scenario in res_scenarios %}
       <div class="card bg-light mb-3">
         <div class="card-body">
           <h5 class="card-title">{{ scenario['title'] }}</h5>
@@ -60,9 +64,7 @@
           >
         </div>
       </div>
-      {% end %} {% else %}
-      <h1>No escape rooms found</h1>
-      {% end %}
+      {% end %} {% end %}
     </div>
   </body>
 </html>

--- a/scripts/mockdata/scenarios_e1.json
+++ b/scripts/mockdata/scenarios_e1.json
@@ -2,7 +2,7 @@
   {
     "name": "Youth in Crisis",
     "friendly_name": "youth-in-crisis",
-    "description": "A youth is experiencing a crisis and they need to seek help for said crisis (i.e. You find yourself sitting at your desk needing to find a way out. The History Teacher is talking about the paper that is due in a week, you look down and see you haven’t even started writing your paper. You think back to the fact that you still have one Biology lab, one Math quiz and one Chemistry exam in the same week. The room begins to feel like it’s slanting, your palms are sweating, you feel your heart beating faster and your hands begin to shake – how will you escape and find help?)",
+    "description": "You find yourself sitting at your desk needing to find a way out. The History Teacher is talking about the paper that is due in a week, you look down and see you haven’t even started writing your paper. You think back to the fact that you still have one Biology lab, one Math quiz and one Chemistry exam in the same week. The room begins to feel like it’s slanting, your palms are sweating, you feel your heart beating faster and your hands begin to shake – how will you escape and find help?",
     "scene_ids": [8, 9, 10, 11, 12],
     "is_published": true,
     "is_previewable": true,


### PR DESCRIPTION
Request from client:
- remove plural since only one room
- change verbiage of room to be just the content in the brackets

Before:
![image](https://user-images.githubusercontent.com/13268990/144461178-517b7510-177a-4c4f-977e-82f562e55059.png)

After:
![image](https://user-images.githubusercontent.com/13268990/144461201-94038074-67e4-4993-b901-3396c2d28393.png)
