### PR TITLE
Add rel noopener noreferrer to target blank link

### DIFF
--- a/app/public/templates/completed_page.html
+++ b/app/public/templates/completed_page.html
@@ -72,6 +72,7 @@
             <a
               href="{{ scenario_conclusion_data['external_link'] }}"
               target="_blank"
+              rel="noopener noreferrer"
               >here</a
             >
             or visiting the link below:


### PR DESCRIPTION
Read this article talking about how target="_blank" is not safe, and we should be using a rel attribute with noopener and noreferrer. Made this change in the only place we have a target="_blank" in the repo.

Article: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/