### PR TITLE
Switch to JS on repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This script will output a JSON object – you can use the `idToken` value and p
 5. Check the box in the top right corner for `ECMAScript 2021 (via babel-minify)`
 6. Hit `Compress`
 7. Download the file as `component.min.js` and place it in `app/public/static/js/`
+8. Update the repo https://github.com/jaydhulia/blueprint-cdc-static
 
 ## Deployment
 

--- a/app/public/templates/scene.html
+++ b/app/public/templates/scene.html
@@ -26,7 +26,7 @@
 {#    <script src="/static/js/components/interactable.js"></script>    #}
 {#    <script src="/static/js/components/button-design.js"></script>    #}
 
-    <script src="/static/js/components.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/jaydhulia/blueprint-cdc-static/components.min.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NCV4M5LZE1"></script>
     <script>

--- a/app/public/templates/tutorial.html
+++ b/app/public/templates/tutorial.html
@@ -29,7 +29,7 @@
     <script src="/static/js/components/tutorial-instructions.js"></script>
     #}
 
-    <script src="/static/js/components.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/jaydhulia/blueprint-cdc-static/components.min.js"></script>
     <!-- Initial state -->
     <script>
       AFRAME.registerState({

--- a/configs/dev-aws-config.yaml
+++ b/configs/dev-aws-config.yaml
@@ -22,7 +22,7 @@ asset:
   # don't actually delete from S3
   aws_hard_delete: false
 
-inspector_url: /static/js/libraries/aframe-inspector.js
+inspector_url: https://cdn.jsdelivr.net/gh/jaydhulia/blueprint-cdc-static/aframe-inspector.js
 
 default_data:
   introduction_data: { "header_text": "Welcome to the escape room." }

--- a/configs/dev-config.yaml
+++ b/configs/dev-config.yaml
@@ -21,7 +21,7 @@ asset:
   # always false for local dev env, it doesn't have access to AWS
   aws_hard_delete: false
 
-inspector_url: /static/js/libraries/aframe-inspector.js
+inspector_url: https://cdn.jsdelivr.net/gh/jaydhulia/blueprint-cdc-static/aframe-inspector.js
 
 default_data:
   introduction_data: { "header_text": "Welcome to the escape room." }

--- a/configs/dev-docker-config.yaml
+++ b/configs/dev-docker-config.yaml
@@ -21,7 +21,7 @@ asset:
   # always false for local dev env, it doesn't have access to AWS
   aws_hard_delete: false
 
-inspector_url: /static/js/libraries/aframe-inspector.js
+inspector_url: https://cdn.jsdelivr.net/gh/jaydhulia/blueprint-cdc-static/aframe-inspector.js
 
 default_data:
   introduction_data: { "header_text": "Welcome to the escape room." }


### PR DESCRIPTION
Quick PR to use a-frame inspector JS from CDN so we don't have to redeploy every time there's a change to aframe inspector.